### PR TITLE
FIX: fix meta description tags

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ params:
   # Open graph allows easy social sharing. If you don't want it you can set it to false or just delete the variable
   openGraph: true
   # Used as meta data; describe your site to make Google Bots happy
-  description:
+  description: "A Cryptographic, immutable, append only transparency log"
   navbarlogo:
   # Logo (from static/images/logos/___)
     image: logos/rekor-logo.png


### PR DESCRIPTION
The current deployed site has an annoying banner that says:

    "Hardcoded description; the author should update :)"

Which shows up when either: 1) posting the link in chat applications and
2) when the website is being crawled by web engines. Add a description
tag to improve the website's first impressions.

For what it's worth. I wrote a small test script to verify this is
correct using bs4:

    import bs4
    import urllib.request;

    site = urllib.request.urlopen('http://localhost:1313')
    parsed = bs4.BeautifulSoup(site, features='lxml')
    print(f"Title: {parsed.title.text}")
    description = parsed.head.find_all("meta", attrs={'name': 'description'})[0].attrs['content']
    print(f"Description: {description}")
    og = parsed.head.find_all("meta", attrs={'property': 'og:description'})[0].attrs['content']
    print(f"og:description: {og}")