### PR TITLE
Update Rekor CLI examples

### DIFF
--- a/content/get_started/client.md
+++ b/content/get_started/client.md
@@ -47,7 +47,7 @@ gpg --export --armor "jdoe@example.com" > mypublickey.key
 The `upload` command sends your public key / signature and artifact URL to the rekor transparency log.
 
 ```
-rekor upload --rekor_server api.rekor.dev --signature <artifact_signature> --public-key <your_public_key> --artifact <url_to_artifact>
+rekor upload --rekor_server https://api.rekor.dev --signature <artifact_signature> --public-key <your_public_key> --artifact <url_to_artifact>
 ```
 
 Firstly the rekor command will verify your public key, signature and download
@@ -84,11 +84,11 @@ An entry in the log can be retrieved by using either the log index or the artifa
 This can be performed with the log index, or the UUID
 
 ```
-rekor get --rekor-server api.rekor.dev --log-index <log-index>
+rekor get --rekor-server https://api.rekor.dev --log-index <log-index>
 ```
 
 ```
-rekor get --rekor-server api.rekor.dev --uuid <uuid>
+rekor get --rekor-server https://api.rekor.dev --uuid <uuid>
 ```
 
 ## Log Info
@@ -96,7 +96,7 @@ rekor get --rekor-server api.rekor.dev --uuid <uuid>
 The log info command retrieves the public key of the transparency log (unless already declared within the client `~/.rekor/rekor.yaml`)
 and then uses the public key to verify the signing of the signed tree head.
 
-`rekor loginfo --rekor-server api.rekor.dev`
+`rekor loginfo --rekor-server https://api.rekor.dev`
 
 ## Search
 
@@ -104,4 +104,4 @@ If running a redis instance within rekor, the search command performs a redis lo
 
 This command requires one of a artifact, a public key of a sha. 
 
-`rekor search --rekor-server api.rekor.dev --`
+`rekor search --rekor-server https://api.rekor.dev --`

--- a/content/get_started/client.md
+++ b/content/get_started/client.md
@@ -102,6 +102,6 @@ and then uses the public key to verify the signing of the signed tree head.
 
 If running a redis instance within rekor, the search command performs a redis lookup using a file or a public key
 
-This command requires one of a artifact, a public key of a sha. 
+This command requires one of an artifact, a public key, or a sha.
 
-`rekor search --rekor-server https://api.rekor.dev --`
+`rekor search --rekor-server https://api.rekor.dev --[artifact|public-key|sha]`

--- a/docs/get_started/client/index.html
+++ b/docs/get_started/client/index.html
@@ -9,9 +9,10 @@ The steps outlined below will show how to sign your software and then use the re
 Download the Rekor CLI application Prerequisites You will of course also need golang version 1.15 or greater and a $GOPATH set.
 Build rekor go get -u -t -v github." />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="/get_started/client/" />
-<meta property="article:published_time" content="2020-12-08T08:06:07+00:00" />
-<meta property="article:modified_time" content="2020-12-08T08:06:07+00:00" />
+<meta property="og:url" content="/get_started/client/" /><meta property="article:section" content="get_started" />
+<meta property="article:published_time" content="2020-12-08T08:06:07&#43;00:00" />
+<meta property="article:modified_time" content="2020-12-08T08:06:07&#43;00:00" />
+
 
 
 <meta name="description" content="A non-profit, public good software signing &amp; transparency service" />
@@ -158,7 +159,7 @@ GPG.</p>
 <pre><code>gpg --export --armor &quot;jdoe@example.com&quot; &gt; mypublickey.key
 </code></pre><h2 id="upload-an-entry-rekor">Upload an entry rekor</h2>
 <p>The <code>upload</code> command sends your public key / signature and artifact URL to the rekor transparency log.</p>
-<pre><code>rekor upload --rekor_server api.rekor.dev --signature &lt;artifact_signature&gt; --public-key &lt;your_public_key&gt; --artifact &lt;url_to_artifact&gt;
+<pre><code>rekor upload --rekor_server https://api.rekor.dev --signature &lt;artifact_signature&gt; --public-key &lt;your_public_key&gt; --artifact &lt;url_to_artifact&gt;
 </code></pre><p>Firstly the rekor command will verify your public key, signature and download
 a local copy of the artifact. It will then validate the artifact signing (no
 access to your private key is required).</p>
@@ -177,16 +178,16 @@ in that your artifact is stored within the transparency log.</p>
 <h2 id="get-entry">Get Entry</h2>
 <p>An entry in the log can be retrieved by using either the log index or the artifact uuid:</p>
 <p>This can be performed with the log index, or the UUID</p>
-<pre><code>rekor get --rekor-server api.rekor.dev --log-index &lt;log-index&gt;
-</code></pre><pre><code>rekor get --rekor-server api.rekor.dev --uuid &lt;uuid&gt;
+<pre><code>rekor get --rekor-server https://api.rekor.dev --log-index &lt;log-index&gt;
+</code></pre><pre><code>rekor get --rekor-server https://api.rekor.dev --uuid &lt;uuid&gt;
 </code></pre><h2 id="log-info">Log Info</h2>
 <p>The log info command retrieves the public key of the transparency log (unless already declared within the client <code>~/.rekor/rekor.yaml</code>)
 and then uses the public key to verify the signing of the signed tree head.</p>
-<p><code>rekor loginfo --rekor-server api.rekor.dev</code></p>
+<p><code>rekor loginfo --rekor-server https://api.rekor.dev</code></p>
 <h2 id="search">Search</h2>
 <p>If running a redis instance within rekor, the search command performs a redis lookup using a file or a public key</p>
-<p>This command requires one of a artifact, a public key of a sha.</p>
-<p><code>rekor search --rekor-server api.rekor.dev --</code></p>
+<p>This command requires one of an artifact, a public key, or a sha.</p>
+<p><code>rekor search --rekor-server https://api.rekor.dev --[artifact|public-key|sha]</code></p>
 
     </div>
   </div>


### PR DESCRIPTION
Updates to the getting started page after having run into an error when following it because the rekor_server option requires an absolute URL