### PR TITLE
Update rekor-server instructions + small improvements

### DIFF
--- a/content/get_started/server.md
+++ b/content/get_started/server.md
@@ -1,6 +1,6 @@
 ---
 title: "Run a Rekor Server"
-date: 2020-12-08T08:12:58Z
+date: 2021-05-21T13:00:00Z
 draft: false
 section: single
 type: page
@@ -9,42 +9,50 @@ There are a few ways to deploy a Rekor Server:
 
  1. We have a [docker-compose](https://github.com/sigstore/rekor/blob/main/docker-compose.yml) file available
  2. A [kubernetes operator](https://github.com/sigstore/rekor-operator)
- 3. Or you could do this manually and build rekor yourself.
+ 3. Or you could do this manually and build Rekor yourself.
 
 # Manual Installation
 
 ## Prerequisites
 
-You will of course also need golang version 1.15 or greater and a `$GOPATH` set.
+You will of course also need golang, version 1.15 or greater, and a `$GOPATH` set.
 
-If you want to perform fast queries you will need to add redis, otherwise you must pass the `--enable_retrieve_api=false`
-flag when running `rekor-server` in the later steps of this page.
+You also need a MySQL compatible database and, if you want to perform fast queries, you will need to have an instance of redis running.
+Otherwise, you must pass the `--enable_retrieve_api=false` flag when running `rekor-server` in the later steps of this page.
 
-## Get Rekor
+## Get Rekor source code
 
-Grab the rekor source:
+Grab the Rekor source:
 
 `go get -u -t -v github.com/sigstore/rekor/cmd/server`
 
-> Note: You can also `git clone` should you prefer.
+This will also download the Trillian source code, on which Rekor depends.
+
+> Note: you can also `git clone` should you prefer.
 
 ## Create Database and populate tables
 
 Trillian requires a database, we use MariaDB for now (others to be explored later). Once this
 is installed on your machine, edit the `scripts/createdb.sh` file with your database root account credentials and run the
-script. If you're just trying out rekor, keep the DB user name and password the same as in the script (test/zaphod). If
-you change these, you need to make the changes on Trillian's side (visit the trillian repo for details).
+script.
+
+```
+cd $GOPATH/pkg/mod/github.com/sigstore/rekor@v0.1.1/scripts/
+sh createdeb.sh
+```
+
+If you're just trying out Rekor, keep the DB user name and password the same as in the script (test/zaphod). If
+you change these, you will need to also make the changes on the Trillian side (visit the [Trillian repo](https://github.com/google/trillian) for details).
 
 ## Build Trillian
 
-To run rekor you need to build trillian:
+To run Rekor you need to build Trillian:
 
 ```
-go get -u -t -v github.com/google/trillian
-cd $GOPATH/src/github.com/google/trillian/cmd/trillian_log_server
+cd $GOPATH/pkg/mod/github.com/google/trillian@v1.3.13/cmd/trillian_log_server
 go build
 cp trillian_log_server /usr/local/bin/
-cd $GOPATH/src/github.com/google/trillian/cmd/trillian_log_signer
+cd $GOPATH/pkg/mod/github.com/google/trillian@v1.3.13/cmd/trillian_log_signer
 go build
 cp trillian_log_signer /usr/local/bin/
 ```
@@ -52,28 +60,41 @@ cp trillian_log_signer /usr/local/bin/
 ### Start the tlog server
 
 ```
-trillian_log_server -http_endpoint=localhost:8090 -rpc_endpoint=localhost:8091 --logtostderr ...
+trillian_log_server --logtostderr ...
 ```
 
 ### Start the tlog signer
 
 ```
-trillian_log_signer --logtostderr --force_master --http_endpoint=localhost:8190 -rpc_endpoint=localhost:8191  --batch_size=1000 --sequencer_guard_window=0 --sequencer_interval=200ms
+trillian_log_signer --logtostderr --force_master --rpc_endpoint=localhost:8190 --http_endpoint=localhost:8191 --batch_size=1000 --sequencer_guard_window=0 --sequencer_interval=200ms
 ```
+
+> Note: you can also log both to files and to stderr using `--alsologtostderr`
 
 ## Build Rekor Server
 
 ```
-cd $GOPATH/src/github.com/sigstore/rekor/cmd/server
+cd $GOPATH/pkg/mod/github.com/sigstore/rekor@v0.1.1/cmd/server
 go build -v -o rekor-server
 cp rekor-server /usr/local/bin/
 ```
 
-## Start the rekor server
+## Start the Rekor server
 
 ```
-rekor-server serve
-2020-09-12T16:32:22.705+0100	INFO	cmd/root.go:87	Using config file: /Users/lukehinds/go/src/github.com/sigstore/rekor-server/rekor-server.yaml
-2020-09-12T16:32:22.705+0100	INFO	app/server.go:55	Starting server...
-2020-09-12T16:32:22.705+0100	INFO	app/server.go:61	Listening on 127.0.0.1:3000
+rekor-server serve --trillian_log_server.port=8090
+2021-05-01T09:30:00.224Z        INFO    app/root.go:101 Using config file: /Users/lukehinds/go/pkg/mod/github.com/sigstore@v0.1.1/rekor-server/rekor-server.yaml
+2021-05-01T09:30:00.225Z        INFO    app/serve.go:58 starting rekor-server
+2021-05-01T09:30:00.248Z        INFO    app/serve.go:79 Loading support for pluggable type 'jar'
+2021-05-01T09:30:00.249Z        INFO    app/serve.go:80 Loading version '0.0.1' for pluggable type 'jar'
+2021-05-01T09:30:00.250Z        INFO    app/serve.go:79 Loading support for pluggable type 'rekord'
+2021-05-01T09:30:00.251Z        INFO    app/serve.go:80 Loading version '0.0.1' for pluggable type 'rekord'
+2021-05-01T09:30:00.252Z        INFO    app/serve.go:79 Loading support for pluggable type 'rpm'
+2021-05-01T09:30:00.253Z        INFO    app/serve.go:80 Loading version '0.0.1' for pluggable type 'rpm'
+2021-05-01T09:30:00.288Z        INFO    restapi/server.go:230   Serving rekor server at http://127.0.0.1:3000
 ```
+
+# Nex steps
+
+Congratulations, you now have a Rekor server running. To interact with the Rekor
+server, see the [client](../client) page.


### PR DESCRIPTION
Relates to sigstore/rekor#312

- Use default trillian_log_server ports
- Simplify trillian_log_server command
- Switch trillian_log_signer ports to 8190 (RPC) and 8191 (HTTP)
- Small wording improvements
- Add next steps section: take readers to the CLI page

Signed-off-by: axelsimon <github@axelsimon.net>