### PR TITLE
Fix the path to rekor-cli

### DIFF
--- a/content/get_started/client.md
+++ b/content/get_started/client.md
@@ -19,8 +19,8 @@ You will of course also need golang version 1.15 or greater and a `$GOPATH` set.
 ## Build rekor
 
 ```
-go get -u -t -v github.com/sigstore/rekor/cmd/cli
-cd $GOPATH/src/github.com/sigstore/rekor/cmd/cli
+go get -u -t -v github.com/sigstore/rekor/cmd/rekor-cli
+cd $GOPATH/src/github.com/sigstore/rekor/cmd/rekor-cli
 go build -v -o rekor
 cp rekor /usr/local/bin/
 ```


### PR DESCRIPTION
It has been renamed in https://github.com/sigstore/rekor/commit/06067b04c56d854ae3c23c8020a4efb9715a5d65#diff-9f78cc281959479060158a20bb464f710e3440048549a08a34972c1965173a70
and this page hasn't been updated

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
